### PR TITLE
Add macOS build and install instructions

### DIFF
--- a/Makefile.macos
+++ b/Makefile.macos
@@ -1,0 +1,54 @@
+# -*- mode: makefile -*-
+CXX ?= g++
+CXXFLAGS = -Wall -Wextra -pipe -pedantic $(shell pkg-config --cflags sdl2 SDL2_image SDL2_ttf)
+LDFLAGS = $(shell pkg-config --libs sdl2 SDL2_image SDL2_ttf)
+SRC_DIR = ./src
+OBJ_DIR = ./obj
+TARGET = loopcube
+SRC = $(wildcard src/*.cpp)
+OBJ = $(patsubst %.cpp,obj/%.o,$(SRC))
+
+ifeq ($(strip $(DATA_LOCATION)),)
+CXXFLAGS += -DDATA_LOCATION=\".\"
+else
+CXXFLAGS += -DDATA_LOCATION=\"$(DATA_LOCATION)\"
+endif
+
+CXXFLAGS += -DINPUT_BACKEND_SDL2 -DGRAPHIC_BACKEND_SDL2 -D_SDL2
+
+all: debug
+
+obj/%.o: %.cpp %.hpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@ 
+
+$(TARGET): $(OBJ)
+	$(CXX) -o $(TARGET) $^ $(LDFLAGS) 
+
+
+debug: CXXFLAGS += -g
+debug: setup
+debug: $(TARGET)
+
+release: CXXFLAGS += -O2 -ffast-math
+release: setup
+release: $(TARGET)
+
+install:
+	@echo "Installing... Make sure your binary has DATA_LOCATION set to a loopcube folder"
+	mkdir -p $(DATA_LOCATION)
+	mkdir -p $(PREFIX)
+	cp -r data $(DATA_LOCATION)/data
+	install -m755 $(TARGET) $(PREFIX)/$(TARGET)
+
+uninstall:
+	@echo "Uninstalling... type yes if prompted (be careful)"
+	rm -r $(DATA_LOCATION)
+	rm -r $(PREFIX)/$(TARGET)
+
+setup:
+	@mkdir -p obj/src/
+
+.PHONY: all clean setup debug release install
+clean:
+	rm -rf $(OBJ_DIR)
+	rm -rf $(TARGET)

--- a/README.md
+++ b/README.md
@@ -53,14 +53,17 @@ Run `make -f Makefile.sfml DATA_LOCATION=/usr/local/share/loopcube release`
 On macOS, LoopCube requires GCC to build. Using the regular Xcode development tools will not work.
 
 If you use Homebrew, you can satisfy the dependencies with this command:
+
 `brew install gcc sdl2 sdl2_image sdl2_ttf`
 
 The instructions for building vary depending on which shell you use.
 
 If you use bash (default on 10.14 and below), run:
+
 `CXX=g++-n make -f Makefile.macos DATA_LOCATION=/usr/local/share/loopcube`
 
 If you use zsh (default on 10.15 and later), run:
+
 `CXX=g++-n; make -f Makefile.macos DATA_LOCATION=/usr/local/share/loopcube`
 
 where *n* is the version of GCC installed by Homebrew.

--- a/README.md
+++ b/README.md
@@ -50,9 +50,20 @@ Run `make -f Makefile.sfml DATA_LOCATION=/usr/local/share/loopcube release`
 
 ## MacOS
 
-(((soon)))
+On macOS, LoopCube requires GCC to build. Using the regular Xcode development tools will not work.
 
-Albeit the instructions could be similar to Linux, I am not really sure.
+If you use Homebrew, you can satisfy the dependencies with this command:
+`brew install gcc sdl2 sdl2_image sdl2_ttf`
+
+The instructions for building vary depending on which shell you use.
+
+If you use bash (default on 10.14 and below), run:
+`CXX=g++-n make -f Makefile.macos DATA_LOCATION=/usr/local/share/loopcube`
+
+If you use zsh (default on 10.15 and later), run:
+`CXX=g++-n; make -f Makefile.macos DATA_LOCATION=/usr/local/share/loopcube`
+
+where *n* is the version of GCC installed by Homebrew.
 
 ## Windows
 
@@ -67,7 +78,9 @@ Replace `install` with `uninstall` if you want to remove it.
 
 ## MacOS
 
-(((soon)))
+`sudo make -f Makefile.macos DATA_LOCATION=/usr/local/share/loopcube PREFIX=/usr/local/bin install`
+
+Replace `install` with `uninstall` if you want to remove it.
 
 ## Windows
 


### PR DESCRIPTION
A modified Makefile that works with the macOS `install` and `rm` commands is provided under Makefile.macos. This is just a basis, however, so feel free to make necessary changes.